### PR TITLE
Update tags.conf

### DIFF
--- a/src/default/tags.conf
+++ b/src/default/tags.conf
@@ -1,26 +1,26 @@
-[eventtype=cognito_stream_conn]
+[eventtype=vectra_cognito_stream_conn]
 communicate = enabled
 network = enabled
 
-[eventtype=cognito_stream_dhcp]
+[eventtype=vectra_cognito_stream_dhcp]
 dhcp = enabled
 network = enabled
 session = enabled
 
-[eventtype=cognito_stream_dns]
+[eventtype=vectra_cognito_stream_dns]
 dns = enabled
 network = enabled
 resolution = enabled
 
-[eventtype=cognito_stream_http]
+[eventtype=vectra_cognito_stream_http]
 web = enabled
 
-[eventtype=cognito_stream_x509]
+[eventtype=vectra_cognito_stream_x509]
 certificate = enabled
 ssl = enabled
 tls = enabled
 
-[eventtype=cognit_stream_dhcp]
+[eventtype=vectra_cognit_stream_dhcp]
 dhcp = disabled
 network = disabled
 session = disabled


### PR DESCRIPTION
Fixed the eventtype in the tags.conf. The event name had a mismatch between tags.conf and eventtypes.conf that will prevent proper CIM mapping for the stream metadata