### PR TITLE
Update props.conf

### DIFF
--- a/src/default/props.conf
+++ b/src/default/props.conf
@@ -1,4 +1,6 @@
 [vectra:cognito:stream]
+NO_BINARY_CHECK = true
+SHOULD_LINEMERGE = false
 FIELDALIAS-vectra_cognito_stream_dns_mapping = TTLs AS ttl answers AS answer id_orig_h AS src id_orig_p AS src_port id_resp_h AS dest id_resp_p AS dest_port proto AS transport qclass_name AS record_class qtype_name AS record_type rcode AS reply_code_id rcode_name AS reply_code total_replies AS answer_count trans_id AS transaction_id
 EVAL-authority_answer_count = total_replies - total_answers
 EVAL-message_type = if (saw_query == "true" AND saw_reply == "true", "Query and Response",  if(saw_query == "true", "Query", "Response"))


### PR DESCRIPTION
Updating props.conf to default line merge to false. Ran into an issue at a customer where multiple syslog messages were indexed together when using the new source type because the line merge was not set and it defaults to true.